### PR TITLE
旧版qq提醒失效

### DIFF
--- a/utilities/send-mail.js
+++ b/utilities/send-mail.js
@@ -164,9 +164,9 @@ ${$(
 [CQ:face,id=169]${url + "#" + comment.get("objectId")}`;
     axios
       .get(
-        `https://qmsg.zendee.cn:443/send/${
+        `https://qmsg.zendee.cn/send/${
           process.env.QMSG_KEY
-        }.html?msg=${encodeURIComponent(scContent)}` + qq
+        }?msg=${encodeURIComponent(scContent)}` + qq
       )
       .then(function (response) {
         if (response.status === 200 && response.data.success === true)


### PR DESCRIPTION
由于QQmsg修改了接口导致qq提醒失效，目前修改好了，请求合并